### PR TITLE
[TASK] allow simple recipient lists with full name

### DIFF
--- a/Classes/Domain/Model/LineSeparatedRecipientList.php
+++ b/Classes/Domain/Model/LineSeparatedRecipientList.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Undkonsorten\CuteMailing\Domain\Model;
+
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class LineSeparatedRecipientList extends RecipientList
@@ -19,11 +20,13 @@ class LineSeparatedRecipientList extends RecipientList
     public function getRecipients(int $limit = null, int $offset = null): array
     {
         // @todo validate email addresses?
-        // @todo allow format "FirstName LastName <firstname.lastname@example.org>"?
         $addresses = GeneralUtility::trimExplode("\n", $this->lineSeparatedList, true);
         return array_map(function (string $address, int $position): SimpleRecipient {
             $recipient = new SimpleRecipient();
-            $recipient->setUid($position)->setEmail($address);
+            $splitAddress = explode(' ', str_replace(['"','<','>'],'',$address));
+            $recipient->setUid($position)->setEmail(array_pop($splitAddress));
+            $recipient->setLastName(array_pop($splitAddress) ?? "");
+            $recipient->setFirstName(implode(' ', $splitAddress) ?? "");
             return $recipient;
         }, $addresses, array_keys($addresses));
     }


### PR DESCRIPTION
@kanow IMHO this works with all usual formats for firstname/lastname/email as quotes and '<' '>' are stripped.

formats allowed:
* `user@domain.tld`
* `<user@domain.tld>`
* `Name user@domain.tld`
* `First Middle Last <user@domain.tld>`
* `"First Last" user@domain.tld
`etc.

The `setFirstName()` and `setLastName()` lines could be merged, as the `setFirstName()` method gets 
all the rest of the string anyway, but I think it is more readable now.
