### PR TITLE
[BUGFIX] add image as mail part

### DIFF
--- a/Classes/Services/MailService.php
+++ b/Classes/Services/MailService.php
@@ -254,7 +254,7 @@ class MailService implements SingletonInterface
             function ($match) {
                 $part = $this->createImageMailPartFromUri($match[1]);
                 $cid = $part->getContentId();
-                $this->email->text($part->bodyToString());
+                $this->email->addPart($part);
                 return sprintf('src="cid:%s"', $cid);
             },
             $imageTag


### PR DESCRIPTION
Your current solution `$this->email->text($part->bodyToString());` adds image as the text (`text/plain`) part, which is not working out. You have to use `$this->email->addPart($part);` to attach multiple images correctly and use it as inline images.